### PR TITLE
Add/correct author ORCID(s) in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,8 @@ Package: bboudata
 Title: Data for bbou Project
 Version: 0.4.0
 Authors@R: c(
-    person("Troy", "Hegel", , "troy.hegel@gov.ab.ca", role = "aut"),
+    person("Troy", "Hegel", , "troy.hegel@gov.ab.ca", role = "aut",
+           comment = c(ORCID = "0000-0001-5363-7716")),
     person("Dave", "Hervieux", , "dave.hervieux@gov.ab.ca", role = "aut"),
     person("Barry", "Nobert", , "barry.nobert@gov.ab.ca", role = "aut"),
     person("John", "Boulanger", , "boulange@ecological.bc.ca", role = "aut",


### PR DESCRIPTION
Add Troy Hegel's ORCID (0000-0001-5363-7716).

Reviewed across all non-archived, non-forked poissonconsulting R packages to ensure co-authors and contributors carry their correct ORCID iDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)