### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,5 @@
 ^CODE_OF_CONDUCT\.md$
 ^\.claude$
 ^CLAUDE\.md$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/chk-data-recruitment.R
+++ b/R/chk-data-recruitment.R
@@ -60,18 +60,32 @@
 #' x <- bbourecruit_a
 #' x[1, 4] <- 32L
 #' try(bbd_chk_data_recruitment(x))
-bbd_chk_data_recruitment <- function(data, x_name = deparse(substitute(data)),
-                                     multi_population = FALSE, allow_missing = FALSE) {
+bbd_chk_data_recruitment <- function(
+  data,
+  x_name = deparse(substitute(data)),
+  multi_population = FALSE,
+  allow_missing = FALSE
+) {
   chk::chk_flag(multi_population)
   chk::chk_flag(allow_missing)
 
   nms <- c(
-    "PopulationName", "Year", "Month", "Day", "Cows",
-    "Bulls", "UnknownAdults", "Yearlings", "Calves"
+    "PopulationName",
+    "Year",
+    "Month",
+    "Day",
+    "Cows",
+    "Bulls",
+    "UnknownAdults",
+    "Yearlings",
+    "Calves"
   )
   chk::chk_superset(names(data), nms, x_name = x_name)
 
-  chk::chk_character_or_factor(data$PopulationName, x_name = xname(x_name, "PopulationName"))
+  chk::chk_character_or_factor(
+    data$PopulationName,
+    x_name = xname(x_name, "PopulationName")
+  )
   chk::chk_not_any_na(data$PopulationName, x_name = "PopulationName")
   if (!multi_population) {
     .chk_single_population(data)
@@ -88,7 +102,10 @@ bbd_chk_data_recruitment <- function(data, x_name = deparse(substitute(data)),
   chk::chk_gte(data$Cows, 0, x_name = xname(x_name, "Cows"))
   chk::chk_whole_numeric(data$Bulls, x_name = xname(x_name, "Bulls"))
   chk::chk_gte(data$Bulls, 0, x_name = xname(x_name, "Bulls"))
-  chk::chk_whole_numeric(data$UnknownAdults, x_name = xname(x_name, "UnknownAdults"))
+  chk::chk_whole_numeric(
+    data$UnknownAdults,
+    x_name = xname(x_name, "UnknownAdults")
+  )
   chk::chk_gte(data$UnknownAdults, 0, x_name = xname(x_name, "UnknownAdults"))
   chk::chk_whole_numeric(data$Yearlings, x_name = xname(x_name, "Yearlings"))
   chk::chk_gte(data$Yearlings, 0, x_name = xname(x_name, "Yearlings"))
@@ -96,13 +113,20 @@ bbd_chk_data_recruitment <- function(data, x_name = deparse(substitute(data)),
   chk::chk_gte(data$Calves, 0, x_name = xname(x_name, "Calves"))
 
   if (!allow_missing) {
-    chk::chk_range(data$Month, range = c(1, 12), x_name = xname(x_name, "Month"))
+    chk::chk_range(
+      data$Month,
+      range = c(1, 12),
+      x_name = xname(x_name, "Month")
+    )
     chk::chk_not_any_na(data$Month, x_name = "Month")
     chk::chk_range(data$Day, range = c(1, 31), x_name = xname(x_name, "Day"))
     chk::chk_not_any_na(data$Day, x_name = "Day")
     chk::chk_not_any_na(data$Cows, x_name = xname(x_name, "Cows"))
     chk::chk_not_any_na(data$Bulls, x_name = xname(x_name, "Bulls"))
-    chk::chk_not_any_na(data$UnknownAdults, x_name = xname(x_name, "UnknownAdults"))
+    chk::chk_not_any_na(
+      data$UnknownAdults,
+      x_name = xname(x_name, "UnknownAdults")
+    )
     chk::chk_not_any_na(data$Yearlings, x_name = xname(x_name, "Yearlings"))
     chk::chk_not_any_na(data$Calves, x_name = xname(x_name, "Calves"))
   } else {
@@ -124,7 +148,11 @@ bbd_chk_data_recruitment <- function(data, x_name = deparse(substitute(data)),
     if (any(!placeholder)) {
       obs <- data[!placeholder, , drop = FALSE]
       chk::chk_not_any_na(obs$Month, x_name = "Month")
-      chk::chk_range(obs$Month, range = c(1, 12), x_name = xname(x_name, "Month"))
+      chk::chk_range(
+        obs$Month,
+        range = c(1, 12),
+        x_name = xname(x_name, "Month")
+      )
       chk::chk_not_any_na(obs$Day, x_name = "Day")
       chk::chk_range(obs$Day, range = c(1, 31), x_name = xname(x_name, "Day"))
     }

--- a/R/chk-data-survival.R
+++ b/R/chk-data-survival.R
@@ -53,18 +53,29 @@
 #' x <- bbousurv_c
 #' x[1, 3] <- 14L
 #' try(bbd_chk_data_survival(x))
-bbd_chk_data_survival <- function(data, x_name = deparse(substitute(data)),
-                                  multi_population = FALSE, allow_missing = FALSE) {
+bbd_chk_data_survival <- function(
+  data,
+  x_name = deparse(substitute(data)),
+  multi_population = FALSE,
+  allow_missing = FALSE
+) {
   chk::chk_flag(multi_population)
   chk::chk_flag(allow_missing)
 
   nms <- c(
-    "PopulationName", "Year", "Month", "StartTotal",
-    "MortalitiesCertain", "MortalitiesUncertain"
+    "PopulationName",
+    "Year",
+    "Month",
+    "StartTotal",
+    "MortalitiesCertain",
+    "MortalitiesUncertain"
   )
   chk::chk_superset(names(data), nms, x_name = x_name)
 
-  chk::chk_character_or_factor(data$PopulationName, x_name = xname(x_name, "PopulationName"))
+  chk::chk_character_or_factor(
+    data$PopulationName,
+    x_name = xname(x_name, "PopulationName")
+  )
   chk::chk_not_any_na(data$PopulationName, x_name = "PopulationName")
   if (!multi_population) {
     .chk_single_population(data)
@@ -78,19 +89,44 @@ bbd_chk_data_survival <- function(data, x_name = deparse(substitute(data)),
   chk::chk_whole_numeric(data$Month, x_name = xname(x_name, "Month"))
   chk::chk_whole_numeric(data$StartTotal, x_name = xname(x_name, "StartTotal"))
   chk::chk_gte(data$StartTotal, 0, x_name = xname(x_name, "StartTotal"))
-  chk::chk_whole_numeric(data$MortalitiesCertain, x_name = xname(x_name, "MortalitiesCertain"))
-  chk::chk_gte(data$MortalitiesCertain, 0, x_name = xname(x_name, "MortalitiesCertain"))
-  chk::chk_whole_numeric(data$MortalitiesUncertain, x_name = xname(x_name, "MortalitiesUncertain"))
-  chk::chk_gte(data$MortalitiesUncertain, 0, x_name = xname(x_name, "MortalitiesUncertain"))
+  chk::chk_whole_numeric(
+    data$MortalitiesCertain,
+    x_name = xname(x_name, "MortalitiesCertain")
+  )
+  chk::chk_gte(
+    data$MortalitiesCertain,
+    0,
+    x_name = xname(x_name, "MortalitiesCertain")
+  )
+  chk::chk_whole_numeric(
+    data$MortalitiesUncertain,
+    x_name = xname(x_name, "MortalitiesUncertain")
+  )
+  chk::chk_gte(
+    data$MortalitiesUncertain,
+    0,
+    x_name = xname(x_name, "MortalitiesUncertain")
+  )
 
   if (!allow_missing) {
-    chk::chk_range(data$Month, range = c(1, 12), x_name = xname(x_name, "Month"))
+    chk::chk_range(
+      data$Month,
+      range = c(1, 12),
+      x_name = xname(x_name, "Month")
+    )
     chk::chk_not_any_na(data$Month, x_name = "Month")
     chk::chk_not_any_na(data$StartTotal, x_name = "StartTotal")
     chk::chk_not_any_na(data$MortalitiesCertain, x_name = "MortalitiesCertain")
-    chk::chk_not_any_na(data$MortalitiesUncertain, x_name = "MortalitiesUncertain")
+    chk::chk_not_any_na(
+      data$MortalitiesUncertain,
+      x_name = "MortalitiesUncertain"
+    )
     chk::check_key(data, c("PopulationName", "Year", "Month"))
-    .chk_sum_less(data, c("MortalitiesCertain", "MortalitiesUncertain"), "StartTotal")
+    .chk_sum_less(
+      data,
+      c("MortalitiesCertain", "MortalitiesUncertain"),
+      "StartTotal"
+    )
   } else {
     .chk_placeholder_all_or_nothing(
       data,
@@ -105,10 +141,19 @@ bbd_chk_data_survival <- function(data, x_name = deparse(substitute(data)),
     if (any(!placeholder)) {
       obs <- data[!placeholder, , drop = FALSE]
       chk::chk_not_any_na(obs$Month, x_name = "Month")
-      chk::chk_range(obs$Month, range = c(1, 12), x_name = xname(x_name, "Month"))
+      chk::chk_range(
+        obs$Month,
+        range = c(1, 12),
+        x_name = xname(x_name, "Month")
+      )
       chk::check_key(obs, c("PopulationName", "Year", "Month"))
     }
-    .chk_sum_less(data, c("MortalitiesCertain", "MortalitiesUncertain"), "StartTotal", na.rm = TRUE)
+    .chk_sum_less(
+      data,
+      c("MortalitiesCertain", "MortalitiesUncertain"),
+      "StartTotal",
+      na.rm = TRUE
+    )
   }
 
   invisible(data)

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/scripts/build.R
+++ b/scripts/build.R
@@ -14,7 +14,10 @@
 # limitations under the License.
 
 roxygen2md::roxygen2md()
-styler::style_pkg(filetype = c("R", "Rmd"))
+
+system2("air", c("format", "."))
+styler::style_pkg(filetype = c("Rmd")) # Air currently doesn't format .Rmd files
+
 lintr::lint_package(
   linters = lintr::linters_with_defaults(
     line_length_linter = lintr::line_length_linter(400)

--- a/tests/testthat/test-bbourecruit.R
+++ b/tests/testthat/test-bbourecruit.R
@@ -24,8 +24,15 @@ test_that("bbousurv snapshots", {
 test_that("column names of bbourecruit_a are correct", {
   expect_identical(
     c(
-      "PopulationName", "Year", "Month", "Day", "Cows", "Bulls",
-      "UnknownAdults", "Yearlings", "Calves"
+      "PopulationName",
+      "Year",
+      "Month",
+      "Day",
+      "Cows",
+      "Bulls",
+      "UnknownAdults",
+      "Yearlings",
+      "Calves"
     ),
     colnames(bbourecruit_a)
   )
@@ -34,8 +41,15 @@ test_that("column names of bbourecruit_a are correct", {
 test_that("column names of bbourecruit_b are correct", {
   expect_identical(
     c(
-      "PopulationName", "Year", "Month", "Day", "Cows", "Bulls",
-      "UnknownAdults", "Yearlings", "Calves"
+      "PopulationName",
+      "Year",
+      "Month",
+      "Day",
+      "Cows",
+      "Bulls",
+      "UnknownAdults",
+      "Yearlings",
+      "Calves"
     ),
     colnames(bbourecruit_b)
   )
@@ -44,8 +58,15 @@ test_that("column names of bbourecruit_b are correct", {
 test_that("column names of bbourecruit_c are correct", {
   expect_identical(
     c(
-      "PopulationName", "Year", "Month", "Day", "Cows", "Bulls",
-      "UnknownAdults", "Yearlings", "Calves"
+      "PopulationName",
+      "Year",
+      "Month",
+      "Day",
+      "Cows",
+      "Bulls",
+      "UnknownAdults",
+      "Yearlings",
+      "Calves"
     ),
     colnames(bbourecruit_c)
   )
@@ -132,7 +153,11 @@ test_that("dates are all valid dates", {
       !is.na(
         as.Date(
           paste0(
-            bbourecruit_a$Year, "-", bbourecruit_a$Month, "-", bbourecruit_a$Day
+            bbourecruit_a$Year,
+            "-",
+            bbourecruit_a$Month,
+            "-",
+            bbourecruit_a$Day
           ),
           "%Y-%m-%d"
         )
@@ -144,7 +169,11 @@ test_that("dates are all valid dates", {
       !is.na(
         as.Date(
           paste0(
-            bbourecruit_b$Year, "-", bbourecruit_b$Month, "-", bbourecruit_b$Day
+            bbourecruit_b$Year,
+            "-",
+            bbourecruit_b$Month,
+            "-",
+            bbourecruit_b$Day
           ),
           "%Y-%m-%d"
         )
@@ -156,7 +185,11 @@ test_that("dates are all valid dates", {
       !is.na(
         as.Date(
           paste0(
-            bbourecruit_c$Year, "-", bbourecruit_c$Month, "-", bbourecruit_c$Day
+            bbourecruit_c$Year,
+            "-",
+            bbourecruit_c$Month,
+            "-",
+            bbourecruit_c$Day
           ),
           "%Y-%m-%d"
         )

--- a/tests/testthat/test-bbousurv.R
+++ b/tests/testthat/test-bbousurv.R
@@ -24,7 +24,11 @@ test_that("bbousurv snapshots", {
 test_that("column names of bbousurv_a are correct", {
   expect_identical(
     c(
-      "PopulationName", "Year", "Month", "StartTotal", "MortalitiesCertain",
+      "PopulationName",
+      "Year",
+      "Month",
+      "StartTotal",
+      "MortalitiesCertain",
       "MortalitiesUncertain"
     ),
     colnames(bbousurv_a)
@@ -34,7 +38,11 @@ test_that("column names of bbousurv_a are correct", {
 test_that("column names of bbousurv_b are correct", {
   expect_identical(
     c(
-      "PopulationName", "Year", "Month", "StartTotal", "MortalitiesCertain",
+      "PopulationName",
+      "Year",
+      "Month",
+      "StartTotal",
+      "MortalitiesCertain",
       "MortalitiesUncertain"
     ),
     colnames(bbousurv_b)
@@ -44,7 +52,11 @@ test_that("column names of bbousurv_b are correct", {
 test_that("column names of bbousurv_c are correct", {
   expect_identical(
     c(
-      "PopulationName", "Year", "Month", "StartTotal", "MortalitiesCertain",
+      "PopulationName",
+      "Year",
+      "Month",
+      "StartTotal",
+      "MortalitiesCertain",
       "MortalitiesUncertain"
     ),
     colnames(bbousurv_c)

--- a/tests/testthat/test-chk-data-recruitment.R
+++ b/tests/testthat/test-chk-data-recruitment.R
@@ -93,7 +93,8 @@ test_that("can accept multiple populations", {
 
   # both flags needed for multi-pop dataset with unobserved years
   expect_equal(
-    bbd_chk_data_recruitment(x, multi_population = TRUE, allow_missing = TRUE), x
+    bbd_chk_data_recruitment(x, multi_population = TRUE, allow_missing = TRUE),
+    x
   )
 
   # multi_population alone works when placeholder rows are removed

--- a/tests/testthat/test-chk-data-survival.R
+++ b/tests/testthat/test-chk-data-survival.R
@@ -124,7 +124,8 @@ test_that("can accept multiple populations", {
 
   # both flags needed for multi-pop dataset with unobserved years
   expect_equal(
-    bbd_chk_data_survival(x, multi_population = TRUE, allow_missing = TRUE), x
+    bbd_chk_data_survival(x, multi_population = TRUE, allow_missing = TRUE),
+    x
   )
 
   # multi_population alone works when placeholder rows are removed


### PR DESCRIPTION
Closes #34

Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)